### PR TITLE
Fix incorrect patch creation when missing fields where treated as present defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 ### Changed
 - Update to Kubernetes v1.16.
 
+### Fixed
+- Use mutation request raw json to create the json patch instead of an unmarshaled object of the raw json. In the
+  past we got marshaled the raw into an object, create a deepcopy of the object that would be the mutator, then
+  marshal both objects and get the patch.
+  This on some cases caused some defaulting on the fields that were not present on the raw json when marshaling/unmarshaling
+  process, so when generating the patch the fields that were defaulted acted as if already existed on the original object and
+  if modified on the mutated object patch on these field were "modifications" instead of "additions".
+
 ## [0.6.0] - 2020-02-16
 ### Changed
 - Update to Kubernetes v1.15.


### PR DESCRIPTION
Closes #44 

Closes #45 because it is merged here already and I've rebased on top of the Kubernetes updates and fixed integrations tests.

Use mutation request raw json to create the json patch instead of an unmarshaled object of the raw json. In the past we got marshaled the raw into an object, create a deepcopy of the object that would be the mutator, then marshal both objects and get the patch.

This on some cases caused some defaulting on the fields that were not present on the raw json when marshaling/unmarshaling process, so when generating the patch the fields that were defaulted acted as if already existed on the original object and if modified on the mutated object patch on these field were "modifications" instead of "additions".

Thanks to @luodw for the fix.