### PR TITLE
make AdmissionRequestKey public

### DIFF
--- a/pkg/webhook/context/context.go
+++ b/pkg/webhook/context/context.go
@@ -6,20 +6,22 @@ import (
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 )
 
-type contextKey string
+type contextKey struct {
+	name string
+}
 
-var admissionRequestKey = contextKey("admissionRequest")
+var AdmissionRequestKey = &contextKey{"admissionRequest"}
 
 // SetAdmissionRequest will set a admission request on the context and return the new context that has
 // the admission request set.
 func SetAdmissionRequest(ctx context.Context, ar *admissionv1beta1.AdmissionRequest) context.Context {
-	return context.WithValue(ctx, admissionRequestKey, ar)
+	return context.WithValue(ctx, AdmissionRequestKey, ar)
 }
 
 // GetAdmissionRequest returns the admission request stored on the context. If there is no admission
 // request on the context it will return nil.
 func GetAdmissionRequest(ctx context.Context) *admissionv1beta1.AdmissionRequest {
-	val := ctx.Value(admissionRequestKey)
+	val := ctx.Value(AdmissionRequestKey)
 	if ar, ok := val.(*admissionv1beta1.AdmissionRequest); ok {
 		return ar
 	}


### PR DESCRIPTION
Make AdmissionRequestKey to be public. So that validator or mutator can get AdmissionRequest with `context.Value(AdmissionRequestKey)`.