### PR TITLE
Update go version for examples Dockerfile

### DIFF
--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10-alpine AS build-stage
+FROM golang:1.13-alpine AS build-stage
 
 ARG example
 


### PR DESCRIPTION
https://github.com/slok/kubewebhook/issues/60

 Go version in `examples/Dockerfile` should be updated to at least 1.13
https://github.com/slok/kubewebhook/blob/master/examples/Dockerfile#L1

The version has been updated in most other places in https://github.com/slok/kubewebhook/commit/e1705517587ca08b8c0dd2e39d7e25cf1d092c12 


Trying to build as is results in the error:
 
```
 Step 5/9 : RUN CGO_ENABLED=0 go build -o /bin/example --ldflags "-w -extldflags '-static'"  github.com/slok/kubewebhook/examples/${example}
 ---> Running in 7a05851f052e
# github.com/slok/kubewebhook/vendor/k8s.io/apimachinery/pkg/util/errors
vendor/k8s.io/apimachinery/pkg/util/errors/errors.go:99:10: undefined: errors.Is

# github.com/slok/kubewebhook/vendor/sigs.k8s.io/structured-merge-diff/v3/value
vendor/sigs.k8s.io/structured-merge-diff/v3/value/mapreflect.go:95:13: val.MapRange undefined (type reflect.Value has no field or method MapRange)
vendor/sigs.k8s.io/structured-merge-diff/v3/value/mapreflect.go:173:14: rhs.MapRange undefined (type reflect.Value has no field or method MapRange)
vendor/sigs.k8s.io/structured-merge-diff/v3/value/mapreflect.go:194:13: lhs.MapRange undefined (type reflect.Value has no field or method MapRange)
The command '/bin/sh -c CGO_ENABLED=0 go build -o /bin/example --ldflags "-w -extldflags '-static'"  github.com/slok/kubewebhook/examples/${example}' returned a non-zero code: 2
make: *** [build-examples] Error 2
```