### PR TITLE
On DELETE operation reviews, unmarshal object from OldObject data instead of Object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Added
 - Dynamic type webhooks without the need to a specific type (can use as multitype webhook).
 
+### Changed
+- Fixed on `DELETE` operations static webhooks not receiving object unmarshalled (#41)
+- Fixed on `DELETE` operations dynamic webhooks having unmarshaling errors (#63)
 
 ## [0.9.1] - 2020-04-09
 ### Changed

--- a/pkg/webhook/mutating/webhook_test.go
+++ b/pkg/webhook/mutating/webhook_test.go
@@ -174,6 +174,24 @@ func TestPodAdmissionReviewMutation(t *testing.T) {
 			},
 		},
 
+		"A static webhook review of delete operation in a Pod should not fail.": {
+			cfg:     mutating.WebhookConfig{Name: "test", Obj: &corev1.Pod{}},
+			mutator: getPodResourceLimitDeletorMutator(),
+			review: &admissionv1beta1.AdmissionReview{
+				Request: &admissionv1beta1.AdmissionRequest{
+					Operation: admissionv1beta1.Delete,
+					UID:       "test",
+					OldObject: runtime.RawExtension{
+						Raw: getPodJSON(),
+					},
+				},
+			},
+			expPatch: []string{
+				`{"op":"remove","path":"/spec/containers/0/resources/limits"}`,
+				`{"op":"remove","path":"/spec/containers/1/resources/limits"}`,
+			},
+		},
+
 		"A dynamic webhook review of a Pod with an ns mutator should mutate the ns.": {
 			cfg:     mutating.WebhookConfig{Name: "test"},
 			mutator: getPodNSMutator("myChangedNS"),
@@ -253,6 +271,58 @@ func TestPodAdmissionReviewMutation(t *testing.T) {
 				Request: &admissionv1beta1.AdmissionRequest{
 					UID: "test",
 					Object: runtime.RawExtension{
+						Raw: []byte(`
+						{
+							"kind": "whatever",
+							"apiVersion": "v42",
+							"metadata": {
+								"name":"something",
+								"namespace":"someplace",
+								"labels": {
+									"test1": "value1"
+								},
+								"annotations":{
+									"key1":"val1",
+									"key2":"val2"
+								}
+							},
+							"spec": {
+								"n": 42 
+							}
+						}`),
+					},
+				},
+			},
+			expPatch: []string{
+				`{"op":"replace","path":"/metadata/labels/test1","value":"mutated-value1"}`,
+				`{"op":"add","path":"/metadata/labels/test2","value":"mutated-value2"}`,
+			},
+		},
+
+		"A dynamic webhook delete operaiton review of a an unknown type should be able to mutate with the common object attributes (check unstructured object mutation).": {
+			cfg: mutating.WebhookConfig{Name: "test"},
+			mutator: mutating.MutatorFunc(func(_ context.Context, obj metav1.Object) (bool, error) {
+				// Just a check to validate that is unstructured.
+				if _, ok := obj.(runtime.Unstructured); !ok {
+					return true, fmt.Errorf("not unstructured")
+				}
+
+				// Mutate.
+				labels := obj.GetLabels()
+				if labels == nil {
+					labels = map[string]string{}
+				}
+				labels["test1"] = "mutated-value1"
+				labels["test2"] = "mutated-value2"
+				obj.SetLabels(labels)
+
+				return false, nil
+			}),
+			review: &admissionv1beta1.AdmissionReview{
+				Request: &admissionv1beta1.AdmissionRequest{
+					UID:       "test",
+					Operation: admissionv1beta1.Delete,
+					OldObject: runtime.RawExtension{
 						Raw: []byte(`
 						{
 							"kind": "whatever",

--- a/pkg/webhook/mutating/webhook_test.go
+++ b/pkg/webhook/mutating/webhook_test.go
@@ -174,7 +174,7 @@ func TestPodAdmissionReviewMutation(t *testing.T) {
 			},
 		},
 
-		"A static webhook review of delete operation in a Pod should not fail.": {
+		"A static webhook review of delete operation in a Pod should mutate the pod correctly.": {
 			cfg:     mutating.WebhookConfig{Name: "test", Obj: &corev1.Pod{}},
 			mutator: getPodResourceLimitDeletorMutator(),
 			review: &admissionv1beta1.AdmissionReview{
@@ -299,7 +299,7 @@ func TestPodAdmissionReviewMutation(t *testing.T) {
 			},
 		},
 
-		"A dynamic webhook delete operaiton review of a an unknown type should be able to mutate with the common object attributes (check unstructured object mutation).": {
+		"A dynamic webhook delete operation review of an unknown type should be able to mutate with the common object attributes (check unstructured object mutation).": {
 			cfg: mutating.WebhookConfig{Name: "test"},
 			mutator: mutating.MutatorFunc(func(_ context.Context, obj metav1.Object) (bool, error) {
 				// Just a check to validate that is unstructured.

--- a/test/integration/webhook/helper_test.go
+++ b/test/integration/webhook/helper_test.go
@@ -42,6 +42,15 @@ var (
 		},
 	}
 
+	webhookRulesDeletePod = arv1.RuleWithOperations{
+		Operations: []arv1.OperationType{"DELETE"},
+		Rule: arv1.Rule{
+			APIGroups:   []string{""},
+			APIVersions: []string{"v1"},
+			Resources:   []string{"pods"},
+		},
+	}
+
 	webhookRulesHouseCRD = arv1.RuleWithOperations{
 		Operations: []arv1.OperationType{"CREATE"},
 		Rule: arv1.Rule{

--- a/test/integration/webhook/validating_test.go
+++ b/test/integration/webhook/validating_test.go
@@ -354,7 +354,6 @@ func TestValidatingWebhook(t *testing.T) {
 				assert := assert.New(t)
 				require := require.New(t)
 
-				// Crate a pod and check expectations.
 				p := &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      fmt.Sprintf("test-%d", time.Now().UnixNano()),
@@ -371,7 +370,7 @@ func TestValidatingWebhook(t *testing.T) {
 				err = cli.CoreV1().Pods(p.Namespace).Delete(context.TODO(), p.Name, metav1.DeleteOptions{})
 				require.NoError(err)
 
-				// Give time so deletin takes place.
+				// Give time so deleting takes place.
 				time.Sleep(5 * time.Second)
 
 				// Check expectations.
@@ -403,7 +402,6 @@ func TestValidatingWebhook(t *testing.T) {
 				assert := assert.New(t)
 				require := require.New(t)
 
-				// Crate a pod and check expectations.
 				h := &buildingv1.House{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      fmt.Sprintf("test-%d", time.Now().UnixNano()),
@@ -419,7 +417,7 @@ func TestValidatingWebhook(t *testing.T) {
 				err = crdcli.BuildingV1().Houses(h.Namespace).Delete(context.TODO(), h.Name, metav1.DeleteOptions{})
 				require.NoError(err)
 
-				// Give time so deletin takes place.
+				// Give time so deleting takes place.
 				time.Sleep(5 * time.Second)
 
 				// Check expectations.


### PR DESCRIPTION
- Fixes #41 
- Fixes #63 

When Kubernetes sends `DELETE` operations admission reviews, it assumes that the object will be deleted so, the review on `Object` data is empty. this caused two different ways of behavior depending on the type of the webhook:

- Static: The received object by the webhook handler was empty.
- Dynamic: The webhook processing failed with an unmarshal error.

Now when the received review is a `DELETE` operation, the data to unmarshal into the object will be obtained from `OldObject` data that comes with the review request.