### PR TITLE
Back to Ngrok on integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,19 +7,19 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     # Execute the checks inside the container instead the VM.
-    container: golangci/golangci-lint:v1.27.0-alpine
+    container: golangci/golangci-lint:v1.31.0-alpine
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - run: ./hack/scripts/check.sh
 
   unit-test:
     name: Unit test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-go@v2-beta
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.15
       - run: make ci-unit-test
 
   integration-test:
@@ -27,14 +27,29 @@ jobs:
     runs-on: ubuntu-latest
     needs: [check, unit-test]
     strategy:
+      max-parallel: 1 # Due to ngrok account limits.
       matrix:
-        kubernetes: [1.16.9, 1.17.5, 1.18.2]
-    env:
-      KIND_VERSION: v0.8.1
+        kubernetes: [1.18.8, 1.19.1]
     steps:
-      - uses: actions/checkout@v1
-      # Prepare for SSH tunnels with Serveo so we can expose the webhooks on integration tests.
-      - run: mkdir -p ~/.ssh && echo -e "Host serveo.net\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
-      - run: curl -Lo kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64 && chmod +x kind && sudo mv kind /usr/local/bin/
-      - run: curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v${{ matrix.kubernetes }}/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
-      - run: KUBERNETES_VERSION=${{ matrix.kubernetes }} make ci-integration-test
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+      - name: Execute tests
+        env:
+          KIND_VERSION: v0.9.0
+          NGROK_SSH_PRIVATE_KEY_B64: ${{secrets.NGROK_SSH_PRIVATE_KEY_B64}}
+        run: |
+          # Prepare access.
+          mkdir -p ~/.ssh/
+          echo -e "Host tunnel.us.ngrok.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
+          echo -e ${NGROK_SSH_PRIVATE_KEY_B64} | base64 -d > ~/.ssh/id_ed25519
+          chmod 400 ~/.ssh/id_ed25519
+
+          # Download dependencies.
+          curl -Lo kind https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64 && chmod +x kind && sudo mv kind /usr/local/bin/
+          curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v${{ matrix.kubernetes }}/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+          curl -Lo /tmp/ngrok.zip https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip && unzip -o /tmp/ngrok.zip -d /tmp && sudo mv /tmp/ngrok /usr/local/bin/ && rm -rf /tmp/ngrok.zip
+
+          # Execute tests.
+          KUBERNETES_VERSION=${{ matrix.kubernetes }} NGROK=true make ci-integration-test

--- a/hack/scripts/run-integration.sh
+++ b/hack/scripts/run-integration.sh
@@ -7,12 +7,7 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 TUNNEL_INFO_PATH="/tmp/$(openssl rand -hex 12)-ngrok-tcp-tunnel"
 LOCAL_PORT=8080
 KUBERNETES_VERSION=v${KUBERNETES_VERSION:-1.17.0}
-K3S=${K3S:-false}
 PREVIOUS_KUBECTL_CONTEXT=$(kubectl config current-context) || PREVIOUS_KUBECTL_CONTEXT=""
-SUDO=''
-if [[ $(id -u) -ne 0 ]]; then
-    SUDO="sudo"
-fi
 # If NGROK used, we need ngrok key in b64 set in `NGROK_SSH_PRIVATE_KEY_B64`:
 #   - echo -e "Host tunnel.us.ngrok.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
 #   - echo -e ${NGROK_SSH_PRIVATE_KEY_B64} | base64 -d > ~/.ssh/id_ed25519
@@ -22,17 +17,11 @@ fi
 NGROK=${NGROK:-false}
 
 function cleanup {
-    if [ "${K3S}" = true ]; then
-        echo "=> Removing K3S cluster"
-        $SUDO kill ${K3S_PID}
-        $SUDO killall containerd-shim
-    else
-        echo "=> Removing kind cluster"
-        kind delete cluster
-        if [ ! -z ${PREVIOUS_KUBECTL_CONTEXT} ]; then 
-            echo "=> Setting previous kubectl context"
-            kubectl config use-context ${PREVIOUS_KUBECTL_CONTEXT}
-        fi
+    echo "=> Removing kind cluster"
+    kind delete cluster
+    if [ ! -z ${PREVIOUS_KUBECTL_CONTEXT} ]; then 
+        echo "=> Setting previous kubectl context"
+        kubectl config use-context ${PREVIOUS_KUBECTL_CONTEXT}
     fi
 
     echo "=> Removing SSH tunnel"
@@ -41,19 +30,11 @@ function cleanup {
 trap cleanup EXIT
 
 # Start Kubernetes cluster.
-if [ "${K3S}" = true ]; then
-    echo "Start K3S cluster..."
-    $SUDO k3s server &
-    K3S_PID=$!
-    export KUBECONFIG="/etc/rancher/k3s/k3s.yaml"
-    $SUDO chmod a+rw ${KUBECONFIG}
-else
-    echo "Start Kind Kubernetes ${KUBERNETES_VERSION} cluster..."
-    kind create cluster --image kindest/node:${KUBERNETES_VERSION}
-    export KUBECONFIG="${HOME}/.kube/config"
-    chmod a+rw ${KUBECONFIG}
-    kubectl config use-context kind-kind
-fi
+echo "Start Kind Kubernetes ${KUBERNETES_VERSION} cluster..."
+kind create cluster --image kindest/node:${KUBERNETES_VERSION}
+export KUBECONFIG="${HOME}/.kube/config"
+chmod a+rw ${KUBECONFIG}
+kubectl config use-context kind-kind
 
 # Sleep a bit so the cluster can start correctly.
 echo "Sleeping 30s to give the cluster time to set the runtime..."

--- a/test/integration/webhook/validating_test.go
+++ b/test/integration/webhook/validating_test.go
@@ -377,7 +377,7 @@ func TestValidatingWebhook(t *testing.T) {
 				require.NoError(err)
 
 				// Give time so deleting takes place.
-				time.Sleep(10 * time.Second)
+				time.Sleep(15 * time.Second)
 
 				// Check expectations.
 				_, err = cli.CoreV1().Pods(p.Namespace).Get(context.TODO(), p.Name, metav1.GetOptions{})


### PR DESCRIPTION
Move again to Ngrok from Serveo (service stopped). Ngrok has the limitation of one Ngrok tunnel and needs auth.

Also:

- Integration tests reduced to 2 versions of Kubernetes and sequential.
- Updated CI actions with new versions.
- Removed support on K3s on integration tests