### PR TITLE
Add better logger that understands how to log key value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,12 @@
 - http.HandlerFor now receives a configuration struct.
 - Improved the logger on webhooks and HTTP handlers.
 - Use structured logging over the application.
+- Add Logrus logger support.
 
 ### Removed
 
-- V1 docs
+- V1 docs.
+- STD logger.
 
 ## [0.11.0] - 2020-10-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - A new model that decouples the different Kubernetes admission review model types.
+- Support Kubernetes warnings headers in webhooks.
 
 ### Changed
 
@@ -11,6 +12,9 @@
 - Better HTTP reponse details (messages, HTTP codes...) on allow, not allow, mutating and errors.
 - Webhook reviewm metrics have been changed to give more insights.
 - Prometheus metrics have been redesigned and now are simpler and give more insights.
+- http.HandlerFor now receives a configuration struct.
+- Improved the logger on webhooks and HTTP handlers.
+- Use structured logging over the application.
 
 ### Removed
 

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,6 @@ default: help
 .PHONY: build
 build: ## Build the development docker images.
 	docker build -t $(SERVICE_NAME) --build-arg uid=$(UID) --build-arg  gid=$(GID) -f ./docker/dev/Dockerfile .
-	docker build -t $(SERVICE_NAME)-docs --build-arg uid=$(UID) --build-arg  gid=$(GID) -f ./docker/docs/Dockerfile .
 
 build-binary: ## Build production stuff.
 	$(DOCKER_RUN_CMD) /bin/sh -c '$(BUILD_BINARY_CMD)'

--- a/Readme.md
+++ b/Readme.md
@@ -19,7 +19,9 @@ With Kubewebhook you can make validating and mutating webhooks in any version, f
 - Webhook metrics ([RED][red-metrics-url]) for [Prometheus][prometheus-url] with [Grafana dashboard][grafana-dashboard] included.
 - Supports [warnings].
 
-## Example
+## Getting started
+
+**Use `github.com/slok/kubewebhook/v2` to import Kubewebhook `v2`.**
 
 ```go
 func run() error {
@@ -43,18 +45,17 @@ func run() error {
     })
 
     // Create webhook.
-    mcfg := kwhmutating.WebhookConfig{
+    wh, err := kwhmutating.NewWebhook(kwhmutating.WebhookConfig{
         ID:      "pod-annotate",
         Mutator: mt,
         Logger:  logger,
-    }
-    wh, err := kwhmutating.NewWebhook(mcfg)
+    })
     if err != nil {
         return fmt.Errorf("error creating webhook: %w", err)
     }
 
     // Get HTTP handler from webhook.
-    whHandler, err := kwhhttp.HandlerFor(wh)
+    whHandler, err := kwhhttp.HandlerFor(kwhhttp.HandlerConfig{Webhook: wh, Logger: logger})
     if err != nil {
         return fmt.Errorf("error creating webhook handler: %w", err)
     }

--- a/examples/dynamicwebhook/main.go
+++ b/examples/dynamicwebhook/main.go
@@ -65,7 +65,7 @@ func main() {
 	}
 
 	// Get the handler for our webhook.
-	whHandler, err := kwhhttp.HandlerFor(wh)
+	whHandler, err := kwhhttp.HandlerFor(kwhhttp.HandlerConfig{Webhook: wh, Logger: logger})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error creating webhook handler: %s", err)
 		os.Exit(1)

--- a/examples/dynamicwebhook/main.go
+++ b/examples/dynamicwebhook/main.go
@@ -9,8 +9,9 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/sirupsen/logrus"
 	kwhhttp "github.com/slok/kubewebhook/v2/pkg/http"
-	kwhlog "github.com/slok/kubewebhook/v2/pkg/log"
+	kwhlogrus "github.com/slok/kubewebhook/v2/pkg/log/logrus"
 	kwhmodel "github.com/slok/kubewebhook/v2/pkg/model"
 	kwhmutating "github.com/slok/kubewebhook/v2/pkg/webhook/mutating"
 	mutatingwh "github.com/slok/kubewebhook/v2/pkg/webhook/mutating"
@@ -33,7 +34,9 @@ func initFlags() *config {
 }
 
 func main() {
-	logger := &kwhlog.Std{Debug: true}
+	logrusLogEntry := logrus.NewEntry(logrus.New())
+	logrusLogEntry.Logger.SetLevel(logrus.DebugLevel)
+	logger := kwhlogrus.NewLogrus(logrusLogEntry)
 
 	cfg := initFlags()
 

--- a/examples/ingress-host-validator/main.go
+++ b/examples/ingress-host-validator/main.go
@@ -8,8 +8,10 @@ import (
 	"os"
 	"regexp"
 
+	"github.com/sirupsen/logrus"
 	kwhhttp "github.com/slok/kubewebhook/v2/pkg/http"
 	kwhlog "github.com/slok/kubewebhook/v2/pkg/log"
+	kwhlogrus "github.com/slok/kubewebhook/v2/pkg/log/logrus"
 	kwhmodel "github.com/slok/kubewebhook/v2/pkg/model"
 	kwhvalidating "github.com/slok/kubewebhook/v2/pkg/webhook/validating"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
@@ -66,7 +68,9 @@ func initFlags() *config {
 }
 
 func main() {
-	logger := &kwhlog.Std{Debug: true}
+	logrusLogEntry := logrus.NewEntry(logrus.New())
+	logrusLogEntry.Logger.SetLevel(logrus.DebugLevel)
+	logger := kwhlogrus.NewLogrus(logrusLogEntry)
 
 	cfg := initFlags()
 

--- a/examples/ingress-host-validator/main.go
+++ b/examples/ingress-host-validator/main.go
@@ -100,7 +100,10 @@ func main() {
 
 	// Serve the webhook.
 	logger.Infof("Listening on %s", cfg.addr)
-	err = http.ListenAndServeTLS(cfg.addr, cfg.certFile, cfg.keyFile, kwhhttp.MustHandlerFor(wh))
+	err = http.ListenAndServeTLS(cfg.addr, cfg.certFile, cfg.keyFile, kwhhttp.MustHandlerFor(kwhhttp.HandlerConfig{
+		Webhook: wh,
+		Logger:  logger,
+	}))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error serving webhook: %s", err)
 		os.Exit(1)

--- a/examples/multiwebhook/cmd/multiwebhook/main.go
+++ b/examples/multiwebhook/cmd/multiwebhook/main.go
@@ -65,7 +65,7 @@ func (m *Main) Run() error {
 		return err
 	}
 	mpw = kwhwebhook.NewMeasuredWebhook(metricsRec, mpw)
-	mpwh, err := kwhhttp.HandlerFor(mpw)
+	mpwh, err := kwhhttp.HandlerFor(kwhhttp.HandlerConfig{Webhook: mpw, Logger: m.logger})
 	if err != nil {
 		return err
 	}
@@ -75,7 +75,7 @@ func (m *Main) Run() error {
 		return err
 	}
 	vdw = kwhwebhook.NewMeasuredWebhook(metricsRec, vdw)
-	vdwh, err := kwhhttp.HandlerFor(vdw)
+	vdwh, err := kwhhttp.HandlerFor(kwhhttp.HandlerConfig{Webhook: vdw, Logger: m.logger})
 	if err != nil {
 		return err
 	}

--- a/examples/pod-annotate-metrics/main.go
+++ b/examples/pod-annotate-metrics/main.go
@@ -82,7 +82,10 @@ func run() error {
 	}
 
 	// Get HTTP handler from webhook.
-	whHandler, err := kwhhttp.HandlerFor(kwhwebhook.NewMeasuredWebhook(metricsRec, wh))
+	whHandler, err := kwhhttp.HandlerFor(kwhhttp.HandlerConfig{
+		Webhook: kwhwebhook.NewMeasuredWebhook(metricsRec, wh),
+		Logger:  logger,
+	})
 	if err != nil {
 		return fmt.Errorf("error creating webhook handler: %w", err)
 	}

--- a/examples/pod-annotate-metrics/main.go
+++ b/examples/pod-annotate-metrics/main.go
@@ -9,8 +9,9 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/sirupsen/logrus"
 	kwhhttp "github.com/slok/kubewebhook/v2/pkg/http"
-	kwhlog "github.com/slok/kubewebhook/v2/pkg/log"
+	kwhlogrus "github.com/slok/kubewebhook/v2/pkg/log/logrus"
 	kwhprometheus "github.com/slok/kubewebhook/v2/pkg/metrics/prometheus"
 	kwhmodel "github.com/slok/kubewebhook/v2/pkg/model"
 	kwhwebhook "github.com/slok/kubewebhook/v2/pkg/webhook"
@@ -36,7 +37,9 @@ func initFlags() *config {
 }
 
 func run() error {
-	logger := &kwhlog.Std{Debug: true}
+	logrusLogEntry := logrus.NewEntry(logrus.New())
+	logrusLogEntry.Logger.SetLevel(logrus.DebugLevel)
+	logger := kwhlogrus.NewLogrus(logrusLogEntry)
 
 	cfg := initFlags()
 

--- a/examples/pod-annotate-simple/main.go
+++ b/examples/pod-annotate-simple/main.go
@@ -10,8 +10,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/sirupsen/logrus"
 	kwhhttp "github.com/slok/kubewebhook/v2/pkg/http"
-	kwhlog "github.com/slok/kubewebhook/v2/pkg/log"
+	kwhlogrus "github.com/slok/kubewebhook/v2/pkg/log/logrus"
 	kwhmodel "github.com/slok/kubewebhook/v2/pkg/model"
 	kwhmutating "github.com/slok/kubewebhook/v2/pkg/webhook/mutating"
 )
@@ -33,7 +34,9 @@ func initFlags() *config {
 }
 
 func run() error {
-	logger := &kwhlog.Std{Debug: true}
+	logrusLogEntry := logrus.NewEntry(logrus.New())
+	logrusLogEntry.Logger.SetLevel(logrus.DebugLevel)
+	logger := kwhlogrus.NewLogrus(logrusLogEntry)
 
 	cfg := initFlags()
 

--- a/examples/pod-annotate-simple/main.go
+++ b/examples/pod-annotate-simple/main.go
@@ -69,7 +69,7 @@ func run() error {
 	}
 
 	// Get HTTP handler from webhook.
-	whHandler, err := kwhhttp.HandlerFor(wh)
+	whHandler, err := kwhhttp.HandlerFor(kwhhttp.HandlerConfig{Webhook: wh, Logger: logger})
 	if err != nil {
 		return fmt.Errorf("error creating webhook handler: %w", err)
 	}

--- a/examples/pod-annotate/main.go
+++ b/examples/pod-annotate/main.go
@@ -10,8 +10,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/sirupsen/logrus"
 	kwhhttp "github.com/slok/kubewebhook/v2/pkg/http"
-	kwhlog "github.com/slok/kubewebhook/v2/pkg/log"
+	kwhlogrus "github.com/slok/kubewebhook/v2/pkg/log/logrus"
 	kwhmodel "github.com/slok/kubewebhook/v2/pkg/model"
 	kwhmutating "github.com/slok/kubewebhook/v2/pkg/webhook/mutating"
 )
@@ -52,7 +53,9 @@ func initFlags() *config {
 }
 
 func main() {
-	logger := &kwhlog.Std{Debug: true}
+	logrusLogEntry := logrus.NewEntry(logrus.New())
+	logrusLogEntry.Logger.SetLevel(logrus.DebugLevel)
+	logger := kwhlogrus.NewLogrus(logrusLogEntry)
 
 	cfg := initFlags()
 

--- a/examples/pod-annotate/main.go
+++ b/examples/pod-annotate/main.go
@@ -75,7 +75,7 @@ func main() {
 	}
 
 	// Get the handler for our webhook.
-	whHandler, err := kwhhttp.HandlerFor(wh)
+	whHandler, err := kwhhttp.HandlerFor(kwhhttp.HandlerConfig{Webhook: wh, Logger: logger})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error creating webhook handler: %s", err)
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/onsi/ginkgo v1.13.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/prometheus/client_golang v1.8.0
+	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.6.1
 	github.com/uber/jaeger-client-go v2.25.0+incompatible
 	github.com/uber/jaeger-lib v2.4.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -217,6 +217,7 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -346,6 +347,7 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
+github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=

--- a/pkg/http/example_test.go
+++ b/pkg/http/example_test.go
@@ -38,7 +38,7 @@ func ExampleHandlerFor_serveWebhook() {
 	wh, _ := validating.NewWebhook(cfg)
 
 	// Get webhook handler and serve (webhooks need to be server with TLS).
-	whHandler, _ := whhttp.HandlerFor(wh)
+	whHandler, _ := whhttp.HandlerFor(whhttp.HandlerConfig{Webhook: wh})
 	_ = http.ListenAndServeTLS(":8080", "file.cert", "file.key", whHandler)
 }
 
@@ -70,7 +70,7 @@ func ExampleHandlerFor_serveMultipleWebhooks() {
 		Validator: v,
 	}
 	vwh, _ := validating.NewWebhook(vcfg)
-	vwhHandler, _ := whhttp.HandlerFor(vwh)
+	vwhHandler, _ := whhttp.HandlerFor(whhttp.HandlerConfig{Webhook: vwh})
 
 	mcfg := mutating.WebhookConfig{
 		ID:      "muratingServeWebhook",
@@ -78,7 +78,7 @@ func ExampleHandlerFor_serveMultipleWebhooks() {
 		Mutator: m,
 	}
 	mwh, _ := mutating.NewWebhook(mcfg)
-	mwhHandler, _ := whhttp.HandlerFor(mwh)
+	mwhHandler, _ := whhttp.HandlerFor(whhttp.HandlerConfig{Webhook: mwh})
 
 	// Create a muxer and handle different webhooks in different paths of the server.
 	mux := http.NewServeMux()

--- a/pkg/http/handler.go
+++ b/pkg/http/handler.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"time"
 
 	admissionv1 "k8s.io/api/admission/v1"
@@ -104,16 +105,16 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Setup log data on context.
 	ctx = log.CtxWithValues(ctx, log.Kv{
-		"wh-id":      h.webhook.ID(),
-		"wh-kind":    h.webhook.Kind(),
-		"request-id": ar.ID,
-		"op":         ar.Operation,
-		"wh-version": ar.Version,
-		"dry-run":    ar.DryRun,
-		"kind":       ar.RequestGVK,
-		"ns":         ar.Namespace,
-		"name":       ar.Name,
-		"path":       r.URL.Path,
+		"webhook-id":   h.webhook.ID(),
+		"webhook-kind": h.webhook.Kind(),
+		"request-id":   ar.ID,
+		"op":           ar.Operation,
+		"wh-version":   ar.Version,
+		"dry-run":      ar.DryRun,
+		"kind":         strings.Trim(strings.Join([]string{ar.RequestGVK.Group, ar.RequestGVK.Version, ar.RequestGVK.Kind}, "/"), " /"),
+		"ns":           ar.Namespace,
+		"name":         ar.Name,
+		"path":         r.URL.Path,
 	})
 	logger := h.logger.WithCtx(ctx)
 

--- a/pkg/http/handler_test.go
+++ b/pkg/http/handler_test.go
@@ -40,6 +40,11 @@ func getTestAdmissionReviewV1beta1RequestStr(uid string) string {
 				Kind:    "Pod",
 				Version: "v1",
 			},
+			RequestKind: &metav1.GroupVersionKind{
+				Group:   "core",
+				Kind:    "Pod",
+				Version: "v1",
+			},
 			UID: types.UID(uid),
 			Object: runtime.RawExtension{
 				Object: &corev1.Pod{
@@ -64,6 +69,11 @@ func getTestAdmissionReviewV1RequestStr(uid string) string {
 		},
 		Request: &admissionv1.AdmissionRequest{
 			Kind: metav1.GroupVersionKind{
+				Group:   "core",
+				Kind:    "Pod",
+				Version: "v1",
+			},
+			RequestKind: &metav1.GroupVersionKind{
 				Group:   "core",
 				Kind:    "Pod",
 				Version: "v1",

--- a/pkg/http/handler_test.go
+++ b/pkg/http/handler_test.go
@@ -248,8 +248,10 @@ func TestDefaultWebhookFlow(t *testing.T) {
 			// Mocks.
 			mwh := &webhookmock.Webhook{}
 			test.mock(mwh)
+			mwh.On("ID").Maybe().Return("")
+			mwh.On("Kind").Maybe().Return(model.WebhookKind(""))
 
-			h, err := kubewebhookhttp.HandlerFor(mwh)
+			h, err := kubewebhookhttp.HandlerFor(kubewebhookhttp.HandlerConfig{Webhook: mwh})
 			require.NoError(err)
 
 			req := httptest.NewRequest("GET", "/awesome/webhook", bytes.NewBufferString(test.body))

--- a/pkg/log/ctx.go
+++ b/pkg/log/ctx.go
@@ -1,0 +1,41 @@
+package log
+
+import (
+	"context"
+)
+
+type contextKey string
+
+// contextLogValuesKey used as unique key to store log values in the context.
+const contextLogValuesKey = contextKey("kubewebhook-log-values")
+
+// CtxWithValues returns a copy of parent in which the key values passed have been
+// stored ready to be used using log.Logger.
+func CtxWithValues(parent context.Context, kv Kv) context.Context {
+	// Maybe we have values already set.
+	oldValues, ok := parent.Value(contextLogValuesKey).(Kv)
+	if !ok {
+		oldValues = Kv{}
+	}
+
+	// Copy old and received values into the new kv.
+	newValues := Kv{}
+	for k, v := range oldValues {
+		newValues[k] = v
+	}
+	for k, v := range kv {
+		newValues[k] = v
+	}
+
+	return context.WithValue(parent, contextLogValuesKey, newValues)
+}
+
+// ValuesFromCtx gets the log Key values from a context.
+func ValuesFromCtx(ctx context.Context) Kv {
+	values, ok := ctx.Value(contextLogValuesKey).(Kv)
+	if !ok {
+		return Kv{}
+	}
+
+	return values
+}

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,49 +1,21 @@
 package log
 
-import (
-	"fmt"
-	"log"
-)
-
 // Logger is the interface that the loggers used by the library will use.
 type Logger interface {
 	Infof(format string, args ...interface{})
 	Warningf(format string, args ...interface{})
 	Errorf(format string, args ...interface{})
 	Debugf(format string, args ...interface{})
+	WithValues(values map[string]interface{}) Logger
 }
 
-// Dummy logger doesn't log anything
-var Dummy = &dummy{}
+// Noop logger doesn't log anything.
+const Noop = noop(0)
 
-type dummy struct{}
+type noop int
 
-func (d *dummy) Infof(format string, args ...interface{})    {}
-func (d *dummy) Warningf(format string, args ...interface{}) {}
-func (d *dummy) Errorf(format string, args ...interface{})   {}
-func (d *dummy) Debugf(format string, args ...interface{})   {}
-
-// Std is a wrapper for go standard library logger.
-type Std struct {
-	Debug bool
-}
-
-func (s *Std) logWithPrefix(prefix, format string, args ...interface{}) {
-	format = fmt.Sprintf("%s %s", prefix, format)
-	log.Printf(format, args...)
-}
-
-func (s *Std) Infof(format string, args ...interface{}) {
-	s.logWithPrefix("[INFO]", format, args...)
-}
-func (s *Std) Warningf(format string, args ...interface{}) {
-	s.logWithPrefix("[WARN]", format, args...)
-}
-func (s *Std) Errorf(format string, args ...interface{}) {
-	s.logWithPrefix("[ERROR]", format, args...)
-}
-func (s *Std) Debugf(format string, args ...interface{}) {
-	if s.Debug {
-		s.logWithPrefix("[DEBUG]", format, args...)
-	}
-}
+func (n noop) Infof(format string, args ...interface{})    {}
+func (n noop) Warningf(format string, args ...interface{}) {}
+func (n noop) Errorf(format string, args ...interface{})   {}
+func (n noop) Debugf(format string, args ...interface{})   {}
+func (n noop) WithValues(map[string]interface{}) Logger    { return n }

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,5 +1,10 @@
 package log
 
+import "context"
+
+// Kv is a helper type for structured logging fields usage.
+type Kv = map[string]interface{}
+
 // Logger is the interface that the loggers used by the library will use.
 type Logger interface {
 	Infof(format string, args ...interface{})
@@ -7,6 +12,7 @@ type Logger interface {
 	Errorf(format string, args ...interface{})
 	Debugf(format string, args ...interface{})
 	WithValues(values map[string]interface{}) Logger
+	WithCtx(ctx context.Context) Logger
 }
 
 // Noop logger doesn't log anything.
@@ -19,3 +25,4 @@ func (n noop) Warningf(format string, args ...interface{}) {}
 func (n noop) Errorf(format string, args ...interface{})   {}
 func (n noop) Debugf(format string, args ...interface{})   {}
 func (n noop) WithValues(map[string]interface{}) Logger    { return n }
+func (n noop) WithCtx(ctx context.Context) Logger          { return n }

--- a/pkg/log/logrus/logrus.go
+++ b/pkg/log/logrus/logrus.go
@@ -1,0 +1,21 @@
+package logrus
+
+import (
+	"github.com/sirupsen/logrus"
+
+	"github.com/slok/kubewebhook/v2/pkg/log"
+)
+
+type logger struct {
+	*logrus.Entry
+}
+
+// NewLogrus returns a new log.Logger for a logrus implementation.
+func NewLogrus(l *logrus.Entry) log.Logger {
+	return logger{Entry: l}
+}
+
+func (l logger) WithValues(kv map[string]interface{}) log.Logger {
+	newLogger := l.Entry.WithFields(kv)
+	return NewLogrus(newLogger)
+}

--- a/pkg/log/logrus/logrus.go
+++ b/pkg/log/logrus/logrus.go
@@ -1,6 +1,8 @@
 package logrus
 
 import (
+	"context"
+
 	"github.com/sirupsen/logrus"
 
 	"github.com/slok/kubewebhook/v2/pkg/log"
@@ -18,4 +20,8 @@ func NewLogrus(l *logrus.Entry) log.Logger {
 func (l logger) WithValues(kv map[string]interface{}) log.Logger {
 	newLogger := l.Entry.WithFields(kv)
 	return NewLogrus(newLogger)
+}
+
+func (l logger) WithCtx(ctx context.Context) log.Logger {
+	return l.WithValues(log.ValuesFromCtx(ctx))
 }

--- a/pkg/webhook/metrics.go
+++ b/pkg/webhook/metrics.go
@@ -101,7 +101,7 @@ func (m measuredWebhook) Review(ctx context.Context, ar model.AdmissionReview) (
 			cData.WarningsNumber = len(r.Warnings)
 			m.rec.MeasureMutatingWebhookReviewOp(ctx, MeasureMutatingOpData{
 				MeasureOpCommonData: cData,
-				Mutated:             len(r.JSONPatchPatch) > 0,
+				Mutated:             len(r.JSONPatchPatch) > 0 && string(r.JSONPatchPatch) != "[]",
 			})
 
 		default:

--- a/pkg/webhook/mutating/example_test.go
+++ b/pkg/webhook/mutating/example_test.go
@@ -65,6 +65,6 @@ func ExampleMutator_chainMutatingWebhook() {
 	_, _ = mutating.NewWebhook(mutating.WebhookConfig{
 		ID:      "podWebhook",
 		Obj:     &corev1.Pod{},
-		Mutator: mutating.NewChain(log.Dummy, fakeMut, fakeMut2, fakeMut3),
+		Mutator: mutating.NewChain(log.Noop, fakeMut, fakeMut2, fakeMut3),
 	})
 }

--- a/pkg/webhook/mutating/mutator_test.go
+++ b/pkg/webhook/mutating/mutator_test.go
@@ -102,7 +102,7 @@ func TestMutatorChain(t *testing.T) {
 			mutators := test.mutatorMocks()
 
 			// Execute.
-			chain := mutating.NewChain(log.Dummy, mutators...)
+			chain := mutating.NewChain(log.Noop, mutators...)
 			res, err := chain.Mutate(context.TODO(), nil, test.initalObj)
 
 			// Check result.

--- a/pkg/webhook/mutating/webhook.go
+++ b/pkg/webhook/mutating/webhook.go
@@ -37,7 +37,7 @@ func (c *WebhookConfig) defaults() error {
 	}
 
 	if c.Logger == nil {
-		c.Logger = log.Dummy
+		c.Logger = log.Noop
 	}
 
 	return nil

--- a/pkg/webhook/validating/example_test.go
+++ b/pkg/webhook/validating/example_test.go
@@ -70,7 +70,7 @@ func ExampleValidator_chainValidatingWebhook() {
 	_, _ = validating.NewWebhook(validating.WebhookConfig{
 		ID:        "podWebhook",
 		Obj:       &corev1.Pod{},
-		Validator: validating.NewChain(log.Dummy, fakeVal, fakeVal2, fakeVal3),
+		Validator: validating.NewChain(log.Noop, fakeVal, fakeVal2, fakeVal3),
 	})
 
 }

--- a/pkg/webhook/validating/validator_test.go
+++ b/pkg/webhook/validating/validator_test.go
@@ -120,7 +120,7 @@ func TestValidatorChain(t *testing.T) {
 			validators := test.validatorMocks()
 
 			// Execute.
-			chain := validating.NewChain(log.Dummy, validators...)
+			chain := validating.NewChain(log.Noop, validators...)
 			res, err := chain.Validate(context.TODO(), nil, nil)
 
 			// Check results.

--- a/pkg/webhook/validating/webhook.go
+++ b/pkg/webhook/validating/webhook.go
@@ -35,7 +35,7 @@ func (c *WebhookConfig) defaults() error {
 	}
 
 	if c.Logger == nil {
-		c.Logger = log.Dummy
+		c.Logger = log.Noop
 	}
 
 	return nil

--- a/test/integration/webhook/mutating_test.go
+++ b/test/integration/webhook/mutating_test.go
@@ -387,7 +387,7 @@ func testMutatingWebhookCommon(t *testing.T, version string) {
 
 			// Start mutating webhook server.
 			wh := test.webhook()
-			h := whhttp.MustHandlerFor(wh)
+			h := whhttp.MustHandlerFor(whhttp.HandlerConfig{Webhook: wh})
 			srv := http.Server{
 				Handler: h,
 				Addr:    cfg.ListenAddress,
@@ -470,7 +470,7 @@ func testMutatingWebhookWarnings(t *testing.T) {
 
 			// Start mutating webhook server.
 			wh := test.webhook()
-			h := whhttp.MustHandlerFor(wh)
+			h := whhttp.MustHandlerFor(whhttp.HandlerConfig{Webhook: wh})
 			srv := http.Server{
 				Handler: h,
 				Addr:    cfg.ListenAddress,

--- a/test/integration/webhook/validating_test.go
+++ b/test/integration/webhook/validating_test.go
@@ -502,7 +502,7 @@ func testValidatingWebhookCommon(t *testing.T, version string) {
 
 			// Start validating webhook server.
 			wh := test.webhook()
-			h := whhttp.MustHandlerFor(wh)
+			h := whhttp.MustHandlerFor(whhttp.HandlerConfig{Webhook: wh})
 			srv := http.Server{
 				Handler: h,
 				Addr:    cfg.ListenAddress,
@@ -636,7 +636,7 @@ func testValidatingWebhookWarnings(t *testing.T) {
 
 			// Start validating webhook server.
 			wh := test.webhook()
-			h := whhttp.MustHandlerFor(wh)
+			h := whhttp.MustHandlerFor(whhttp.HandlerConfig{Webhook: wh})
 			srv := http.Server{
 				Handler: h,
 				Addr:    cfg.ListenAddress,


### PR DESCRIPTION
This MR refactors the logging on the application

- Use structured logging.
- HTTP handlers now receive a config struct with the logger.
- Warn the user when Kubernetes warnings are used in v1beta1 webhooks.
- Add logging information to context.
- Add logrus support.