### PR TITLE
Fix logger API to be consistent

### DIFF
--- a/pkg/http/handler.go
+++ b/pkg/http/handler.go
@@ -104,7 +104,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Setup log data on context.
-	ctx = log.CtxWithValues(ctx, log.Kv{
+	ctx = h.logger.SetValuesOnCtx(ctx, log.Kv{
 		"webhook-id":   h.webhook.ID(),
 		"webhook-kind": h.webhook.Kind(),
 		"request-id":   ar.ID,
@@ -116,7 +116,7 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		"name":         ar.Name,
 		"path":         r.URL.Path,
 	})
-	logger := h.logger.WithCtx(ctx)
+	logger := h.logger.WithCtxValues(ctx)
 
 	// Webhook execution logic. This is how we are dealing with the different responses:
 	// |                        | HTTP Code             | status.Code | status.Status | status.Message |
@@ -220,7 +220,7 @@ func (h handler) validatingModelResponseToJSON(ctx context.Context, review model
 	switch review.OriginalAdmissionReview.(type) {
 	case *admissionv1beta1.AdmissionReview:
 		if len(resp.Warnings) > 0 {
-			h.logger.WithCtx(ctx).Warningf("warnings used in a 'v1beta1' webhook")
+			h.logger.WithCtxValues(ctx).Warningf("warnings used in a 'v1beta1' webhook")
 		}
 
 		data, err := json.Marshal(admissionv1beta1.AdmissionReview{
@@ -253,7 +253,7 @@ func (h handler) mutatingModelResponseToJSON(ctx context.Context, review model.A
 	switch review.OriginalAdmissionReview.(type) {
 	case *admissionv1beta1.AdmissionReview:
 		if len(resp.Warnings) > 0 {
-			h.logger.WithCtx(ctx).Warningf("warnings used in a 'v1beta1' webhook")
+			h.logger.WithCtxValues(ctx).Warningf("warnings used in a 'v1beta1' webhook")
 		}
 
 		data, err := json.Marshal(admissionv1beta1.AdmissionReview{

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -12,7 +12,8 @@ type Logger interface {
 	Errorf(format string, args ...interface{})
 	Debugf(format string, args ...interface{})
 	WithValues(values map[string]interface{}) Logger
-	WithCtx(ctx context.Context) Logger
+	WithCtxValues(ctx context.Context) Logger
+	SetValuesOnCtx(parent context.Context, values map[string]interface{}) context.Context
 }
 
 // Noop logger doesn't log anything.
@@ -20,9 +21,10 @@ const Noop = noop(0)
 
 type noop int
 
-func (n noop) Infof(format string, args ...interface{})    {}
-func (n noop) Warningf(format string, args ...interface{}) {}
-func (n noop) Errorf(format string, args ...interface{})   {}
-func (n noop) Debugf(format string, args ...interface{})   {}
-func (n noop) WithValues(map[string]interface{}) Logger    { return n }
-func (n noop) WithCtx(ctx context.Context) Logger          { return n }
+func (n noop) Infof(format string, args ...interface{})                         {}
+func (n noop) Warningf(format string, args ...interface{})                      {}
+func (n noop) Errorf(format string, args ...interface{})                        {}
+func (n noop) Debugf(format string, args ...interface{})                        {}
+func (n noop) WithValues(map[string]interface{}) Logger                         { return n }
+func (n noop) WithCtxValues(context.Context) Logger                             { return n }
+func (n noop) SetValuesOnCtx(parent context.Context, values Kv) context.Context { return parent }

--- a/pkg/log/logrus/logrus.go
+++ b/pkg/log/logrus/logrus.go
@@ -17,11 +17,15 @@ func NewLogrus(l *logrus.Entry) log.Logger {
 	return logger{Entry: l}
 }
 
-func (l logger) WithValues(kv map[string]interface{}) log.Logger {
+func (l logger) WithValues(kv log.Kv) log.Logger {
 	newLogger := l.Entry.WithFields(kv)
 	return NewLogrus(newLogger)
 }
 
-func (l logger) WithCtx(ctx context.Context) log.Logger {
+func (l logger) WithCtxValues(ctx context.Context) log.Logger {
 	return l.WithValues(log.ValuesFromCtx(ctx))
+}
+
+func (l logger) SetValuesOnCtx(parent context.Context, values log.Kv) context.Context {
+	return log.CtxWithValues(parent, values)
 }

--- a/pkg/webhook/mutating/webhook.go
+++ b/pkg/webhook/mutating/webhook.go
@@ -106,7 +106,7 @@ func (w mutatingWebhook) Review(ctx context.Context, ar model.AdmissionReview) (
 		return nil, err
 	}
 
-	w.logger.WithCtx(ctx).Debugf("Webhook mutating review finished with: '%s' JSON Patch", string(res.JSONPatchPatch))
+	w.logger.WithCtxValues(ctx).Debugf("Webhook mutating review finished with: '%s' JSON Patch", string(res.JSONPatchPatch))
 
 	return res, nil
 }

--- a/pkg/webhook/validating/webhook.go
+++ b/pkg/webhook/validating/webhook.go
@@ -109,7 +109,7 @@ func (w validatingWebhook) Review(ctx context.Context, ar model.AdmissionReview)
 		return nil, fmt.Errorf("result is required, validator result is nil")
 	}
 
-	w.logger.WithCtx(ctx).WithValues(log.Kv{"valid": res.Valid}).Debugf("Webhook validating review finished with %q result", res.Valid)
+	w.logger.WithCtxValues(ctx).WithValues(log.Kv{"valid": res.Valid}).Debugf("Webhook validating review finished with %q result", res.Valid)
 
 	// Forge response.
 	return &model.ValidatingAdmissionResponse{


### PR DESCRIPTION
The context log values should be set and get in the same way, having a [`get`](https://github.com/slok/kubewebhook/blob/18ce7fe0b71788e24fa49cfc7644dc1f8217a875/pkg/log/log.go#L15) implementation on the logger and not having a `set` implementation is odd, confusing and if the person using its own logger, implements the withCtx, Kubewebhook may not get correctly the context values because will use a non reimplemented set function.

This forces the users to reimplement both (`set` and `get` operations), users can continue using the [helper](https://github.com/slok/kubewebhook/blob/master/pkg/log/ctx.go) functions that kubewebhook uses if they need.