### PR TITLE
Add certtificate file watcher

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/slok/kubewebhook/v2
 go 1.19
 
 require (
+	github.com/fsnotify/fsnotify v1.6.0
 	github.com/prometheus/client_golang v1.13.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH
 github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
+github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -413,6 +415,7 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8 h1:h+EGohizhe9XlX18rfpa8k8RAc5XyaeamM+0VHRd4lc=
 golang.org/x/sys v0.0.0-20220919091848-fb04ddd9f9c8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/pkg/cert/cert_test.go
+++ b/pkg/cert/cert_test.go
@@ -1,0 +1,109 @@
+package cert
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"testing"
+	"time"
+)
+
+func createTestCrt() error {
+	var err error
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return err
+	}
+	publicCaKey := privateKey.Public()
+
+	//[RFC5280]
+	subjectCa := pkix.Name{
+		CommonName:         "example",
+		OrganizationalUnit: []string{"Example Org Unit"},
+		Organization:       []string{"Example Org"},
+		Country:            []string{"JP"},
+	}
+
+	crttmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               subjectCa,
+		NotAfter:              time.Date(2031, 12, 31, 0, 0, 0, 0, time.UTC),
+		NotBefore:             time.Now(),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+	}
+
+	//Self Sign Certificate
+	certificate, err := x509.CreateCertificate(rand.Reader, crttmpl, crttmpl, publicCaKey, privateKey)
+	if err != nil {
+		return err
+	}
+
+	var f *os.File
+	f, err = os.Create("./example.crt")
+	if err != nil {
+		return err
+	}
+	pem.Encode(f, &pem.Block{Type: "CERTIFICATE", Bytes: certificate})
+	err = f.Close()
+	if err != nil {
+		return err
+	}
+
+	f, err = os.Create("./example.key")
+	if err != nil {
+		return err
+	}
+	derPrivateKey := x509.MarshalPKCS1PrivateKey(privateKey)
+
+	pem.Encode(f, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: derPrivateKey})
+	err = f.Close()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func TestWatch(t *testing.T) {
+	cb := context.Background()
+	ctx, cancel := context.WithCancel(cb)
+	certFile := "./example.crt"
+	keyFile := "./example.key"
+
+	defer func() {
+		os.Remove(certFile)
+		os.Remove(keyFile)
+		cancel()
+	}()
+
+	if err := createTestCrt(); err != nil {
+		t.Error("Failed to create certificate file for the first time.", err)
+	}
+
+	crt, err := New(certFile, keyFile)
+	if err != nil {
+		t.Error("Failed to read certificate file for the first time.", err)
+		os.Exit(1)
+	}
+
+	go func() {
+		if err := crt.Start(ctx); err != nil {
+			t.Error("Unable to start watch for certificate file", err)
+			os.Exit(1)
+		}
+	}()
+
+	time.Sleep(time.Second * 5)
+	if err := createTestCrt(); err != nil {
+		t.Error("Test to create certificate file failed", err)
+	}
+	time.Sleep(time.Second * 1)
+}

--- a/pkg/cert/watch.go
+++ b/pkg/cert/watch.go
@@ -1,0 +1,109 @@
+package cert
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"log"
+	"sync"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+type Certificate struct {
+	currentCert *tls.Certificate
+	sync.RWMutex
+	watcher *fsnotify.Watcher
+
+	certFilePath string
+	keyFilePath  string
+}
+
+// New parses and reads the supplied certificate and key.
+func New(certFile string, keyFile string) (*Certificate, error) {
+	crt := &Certificate{
+		certFilePath: certFile,
+		keyFilePath:  keyFile,
+	}
+
+	if err := crt.loadCert(); err != nil {
+		return nil, fmt.Errorf("unable to load certificate: %w", err)
+	}
+
+	return crt, nil
+}
+
+// loadCert reads the certificate and key files, parses them,
+// and updates the current TLS certificate.
+func (crt *Certificate) loadCert() error {
+	c, err := tls.LoadX509KeyPair(crt.certFilePath, crt.keyFilePath)
+	if err != nil {
+		return err
+	}
+
+	crt.Lock()
+	crt.currentCert = &c
+	crt.Unlock()
+
+	fmt.Println("Updated current TLS certificate")
+
+	return nil
+}
+
+// GetCertificate fetches the currently loaded certificate, which may be nil.
+func (crt *Certificate) GetCert(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	crt.RLock()
+	defer crt.RUnlock()
+	return crt.currentCert, nil
+}
+
+// Start starts monitoring certificate and private key changes.
+func (crt *Certificate) Start(ctx context.Context) error {
+	var err error
+	crt.watcher, err = fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+
+	crts := []string{crt.certFilePath, crt.keyFilePath}
+	for _, c := range crts {
+		if err := crt.watcher.Add(c); err != nil {
+			return err
+		}
+	}
+
+	go crt.watch()
+
+	// Wait until the context is done
+	<-ctx.Done()
+
+	return crt.watcher.Close()
+}
+
+// If an event occurs as a result of file monitoring, read from the channels
+func (crt *Certificate) watch() {
+	for {
+		select {
+		case event := <-crt.watcher.Events:
+			crt.createOrUpdateEvent(event)
+		case err := <-crt.watcher.Errors:
+			log.Fatal("Certificate Watch Error%w", err)
+		}
+	}
+}
+
+// If the file is recreated, start watch anew.
+// If the file content has been modified, read it anew.
+func (crt *Certificate) createOrUpdateEvent(event fsnotify.Event) error {
+	if event.Op&fsnotify.Remove == fsnotify.Remove {
+		if err := crt.watcher.Add(event.Name); err != nil {
+			return err
+		}
+	}
+
+	if err := crt.loadCert(); err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
While it may be outside the scope of kubewebhook, we have added the ability to monitor the certificates used by webhook.

This implementation monitors for certificate updates and replaces certificates when updated. Specifically, the following functions are implemented

- Creation of a watcher
- Obtaining the latest certificate
- Replacing certificates when certificate renewal events occur

In addition, by listening for requests from clients in tls.ClientHelloInfo and lazyloading certificates, the latest certificates can always be used.